### PR TITLE
Protection against overriding attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ And then execute:
 
 - All keys are turned into strings.
 - There is no automatic camel-casing. You name your keys the way you want them.
+- Specifying the same key twice will raise an error. If you want to override the value for a key, use the appropriate bang-method: `#attribute!`, `#collection!`, or `#map!`.
 
 ### Simple attributes
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ And then execute:
 
 - All keys are turned into strings.
 - There is no automatic camel-casing. You name your keys the way you want them.
-- Specifying the same key twice will raise an error. If you want to override the value for a key, use the appropriate bang-method: `#attribute!`, `#collection!`, or `#map!`.
+- Using the same key twice will raise an error by default.
+- To override the value for an existing key, use `#attribute!`, `#collection!`, or `#map!`.
 
 ### Simple attributes
 

--- a/lib/serial.rb
+++ b/lib/serial.rb
@@ -7,4 +7,11 @@ require "serial/rails_helpers"
 
 # Serial namespace. See {Serial::Serializer} for reference.
 module Serial
+  # All serial-specific errors inherit from this error.
+  class Error < StandardError
+  end
+
+  # Raised when an already-defined key is defined again.
+  class DuplicateKeyError < StandardError
+  end
 end

--- a/lib/serial/hash_builder.rb
+++ b/lib/serial/hash_builder.rb
@@ -26,7 +26,8 @@ module Serial
     # @yieldparam value
     # @raise [DuplicateKeyError] if the same key has already been defined.
     def attribute(key, value = nil, &block)
-      check_duplicate_key(key) or attribute!(key, value, &block)
+      check_duplicate_key!(key)
+      attribute!(key, value, &block)
     end
 
     # Same as {#attribute}, but will not raise an error on duplicate keys.
@@ -63,7 +64,8 @@ module Serial
     # @yield [builder]
     # @yieldparam builder [ArrayBuilder]
     def collection(key, &block)
-      check_duplicate_key(key) or collection!(key, &block)
+      check_duplicate_key!(key)
+      collection!(key, &block)
     end
 
     # Same as {#collection}, but will not raise an error on duplicate keys.
@@ -91,7 +93,8 @@ module Serial
     # @yieldparam builder [HashBuilder]
     # @yieldparam value
     def map(key, list, &block)
-      check_duplicate_key(key) or map!(key, list, &block)
+      check_duplicate_key!(key)
+      map!(key, list, &block)
     end
 
     # Same as {#map}, but will not raise an error on duplicate keys.
@@ -115,7 +118,7 @@ module Serial
     # @param key [#to_s]
     # @raise [DuplicateKeyError] if key is defined
     # @return [nil]
-    def check_duplicate_key(key)
+    def check_duplicate_key!(key)
       if @data.has_key?(key.to_s)
         raise DuplicateKeyError, "'#{key}' is already defined"
       end

--- a/lib/serial/hash_builder.rb
+++ b/lib/serial/hash_builder.rb
@@ -24,7 +24,18 @@ module Serial
     # @yield [builder, value] declare nested attribute if block is given
     # @yieldparam builder [HashBuilder] (keep in mind the examples shadow the outer `h` variable)
     # @yieldparam value
+    # @raise [DuplicateKeyError] if the same key has already been defined.
     def attribute(key, value = nil, &block)
+      check_duplicate_key(key) or attribute!(key, value, &block)
+    end
+
+    # Same as {#attribute}, but will not raise an error on duplicate keys.
+    #
+    # @see #attribute
+    # @param (see #attribute)
+    # @yield (see #attribute)
+    # @yieldparam (see #attribute)
+    def attribute!(key, value = nil, &block)
       value = HashBuilder.build(@context, value, &block) if block
       @data[key.to_s] = value
     end
@@ -49,9 +60,20 @@ module Serial
     #
     # @see ArrayBuilder
     # @param key [#to_s]
+    # @yield [builder]
     # @yieldparam builder [ArrayBuilder]
     def collection(key, &block)
-      attribute(key, ArrayBuilder.build(@context, &block))
+      check_duplicate_key(key) or collection!(key, &block)
+    end
+
+    # Same as {#collection}, but will not raise an error on duplicate keys.
+    #
+    # @see #collection
+    # @param (see #collection)
+    # @yield (see #collection)
+    # @yieldparam (see #collection)
+    def collection!(key, &block)
+      attribute!(key, ArrayBuilder.build(@context, &block))
     end
 
     # @api public
@@ -69,12 +91,33 @@ module Serial
     # @yieldparam builder [HashBuilder]
     # @yieldparam value
     def map(key, list, &block)
-      collection(key) do |builder|
+      check_duplicate_key(key) or map!(key, list, &block)
+    end
+
+    # Same as {#map}, but will not raise an error on duplicate keys.
+    #
+    # @see #map
+    # @param (see #map)
+    # @yield (see #map)
+    # @yieldparam (see #map)
+    def map!(key, list, &block)
+      collection!(key) do |builder|
         list.each do |item|
           builder.element do |element|
             element.exec(item, &block)
           end
         end
+      end
+    end
+
+    private
+
+    # @param key [#to_s]
+    # @raise [DuplicateKeyError] if key is defined
+    # @return [nil]
+    def check_duplicate_key(key)
+      if @data.has_key?(key.to_s)
+        raise DuplicateKeyError, "'#{key}' is already defined"
       end
     end
   end

--- a/spec/serial/dsl_spec.rb
+++ b/spec/serial/dsl_spec.rb
@@ -26,6 +26,15 @@ describe "Serial DSL" do
 
         expect(data).to eq({ "hi" => { "hello" => "World" } })
       end
+
+      it "explodes if the attribute already exists" do
+        serializer = Serial::Serializer.new do |h|
+          h.attribute(:hi, "a")
+          h.attribute(:hi, "b")
+        end
+
+        expect { serializer.call(nil, nil) }.to raise_error(Serial::DuplicateKeyError, "'hi' is already defined")
+      end
     end
 
     describe "#map" do
@@ -45,6 +54,17 @@ describe "Serial DSL" do
           ]
         })
       end
+
+      it "explodes if the attribute already exists" do
+        serializer = Serial::Serializer.new do |h|
+          h.attribute(:hi, "a")
+          h.map(:hi, [1]) do |h, id|
+            h.attribute(:id, id)
+          end
+        end
+
+        expect { serializer.call(nil, nil) }.to raise_error(Serial::DuplicateKeyError, "'hi' is already defined")
+      end
     end
 
     describe "#collection" do
@@ -55,6 +75,60 @@ describe "Serial DSL" do
         end
 
         expect(data).to eq({ "numbers" => [] })
+      end
+
+      it "explodes if the attribute already exists" do
+        serializer = Serial::Serializer.new do |h|
+          h.attribute(:hi, "a")
+          h.collection(:hi) do |l|
+            l.element do |h|
+              h.attribute(:id, 1)
+            end
+          end
+        end
+
+        expect { serializer.call(nil, nil) }.to raise_error(Serial::DuplicateKeyError, "'hi' is already defined")
+      end
+    end
+
+    describe "!-methods" do
+      describe "#attribute!" do
+        it "does not explode if the attribute already exists" do
+          serializer = Serial::Serializer.new do |h|
+            h.attribute(:hi, "a")
+            h.attribute!(:hi, "b")
+          end
+
+          expect(serializer.call(nil, nil)).to eq({ "hi" => "b" })
+        end
+      end
+
+      describe "#map!" do
+        it "does not explode if the attribute already exists" do
+          serializer = Serial::Serializer.new do |h|
+            h.attribute(:hi, "a")
+            h.map!(:hi, [1]) do |h, id|
+              h.attribute(:id, id)
+            end
+          end
+
+          expect(serializer.call(nil, nil)).to eq({ "hi" => [{ "id" => 1 }] })
+        end
+      end
+
+      describe "#collection!" do
+        it "does not explode if the attribute already exists" do
+          serializer = Serial::Serializer.new do |h|
+            h.attribute(:hi, "a")
+            h.collection!(:hi) do |l|
+              l.element do |h|
+                h.attribute(:id, 1)
+              end
+            end
+          end
+
+          expect(serializer.call(nil, nil)).to eq({ "hi" => [{ "id" => 1 }] })
+        end
       end
     end
   end


### PR DESCRIPTION
```ruby
ProjectSerializer = Serial::Serializer.new do |h, project|
  h.attribute(:id, project.id)
  h.attribute(:id, project.owner.id) # => boom?
end
```

We could have one method for disallowing it, and one method for allowing it.